### PR TITLE
Organization Menu Setup

### DIFF
--- a/alembic/versions/921e0a2bd6de_add_type_to_businesses.py
+++ b/alembic/versions/921e0a2bd6de_add_type_to_businesses.py
@@ -17,9 +17,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('businesses', sa.Column('active_menu', sa.String()))
-    op.add_column('businesses', sa.Column('menu_list', sa.String()))
+    op.add_column('businesses', sa.Column('business_type', sa.String()))
     pass
+
 
 def downgrade():
     pass

--- a/alembic/versions/921e0a2bd6de_add_type_to_businesses.py
+++ b/alembic/versions/921e0a2bd6de_add_type_to_businesses.py
@@ -1,0 +1,25 @@
+"""add_type_to_businesses
+
+Revision ID: 921e0a2bd6de
+Revises: 4f74855656cc
+Create Date: 2022-03-25 15:36:08.363455
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '921e0a2bd6de'
+down_revision = '4f74855656cc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('businesses', sa.Column('active_menu', sa.String()))
+    op.add_column('businesses', sa.Column('menu_list', sa.String()))
+    pass
+
+def downgrade():
+    pass

--- a/bigfastapi/models/menu_model.py
+++ b/bigfastapi/models/menu_model.py
@@ -1,0 +1,40 @@
+
+import json
+import sqlalchemy.orm as _orm
+from sqlalchemy.schema import Column
+from sqlalchemy.types import String
+from uuid import uuid4
+from bigfastapi.db.database import Base
+from bigfastapi.utils.utils import defaultManu
+
+
+class Menu(Base):
+    __tablename__ = "menus"
+    id = Column(String(255), primary_key=True, index=True, default=uuid4().hex)
+    orgaization_id = Column(String(255), index=True)
+    active_menu = Column(String(2000), default="")
+    menu_list = Column(String(2000), default="")
+
+
+# --------------------------------------------------------------------------------------------------#
+#                                    REPOSITORY LAYER
+# --------------------------------------------------------------------------------------------------#
+
+
+def getActiveMenu(businessType):
+    menuList = defaultManu()
+    return json.dumps(menuList[businessType])
+
+
+def addDefaultMenuList(orgId: str, business_type: str, db: _orm.Session):
+    menuConstruct = Menu(id=uuid4().hex, orgaization_id=orgId,
+                         menu_list=json.dumps(defaultManu()),
+                         active_menu=getActiveMenu(business_type))
+    db.add(menuConstruct)
+    db.commit()
+    db.refresh(menuConstruct)
+    return {"active_menu": menuConstruct.active_menu, "menu_list": menuConstruct.menu_list}
+
+
+async def getOrgMenu(orgId: str, db: _orm.Session):
+    return db.query(Menu).filter(Menu.orgaization_id == orgId).first()

--- a/bigfastapi/models/organisation_models.py
+++ b/bigfastapi/models/organisation_models.py
@@ -30,7 +30,7 @@ class Organization(Base):
     values = Column(String(255), index=True)
     currency = Column(String(5), index=True)
     name = Column(String(255), unique=True, index=True, default="")
-    busines_type = Column(String(225), default="retail")
+    business_type = Column(String(225), default="retail")
     country = Column(String(255), index=True)
     state = Column(String(255), index=True)
     address = Column(String(255), index=True)
@@ -71,24 +71,3 @@ def getActiveMenu(businessType):
 
 async def fetchOrganization(orgId: str, db: _orm.Session):
     return db.query(Organization).filter(Organization.id == orgId).first()
-
-
-async def switchType(switchObj: BusinessSwitch, db: _orm.Session):
-    org = await fetchOrganization(switchObj.id, db)
-    if org:
-        menuList = json.loads(org.menu_list)
-        org.active_menu = json.dumps(menuList[switchObj.business_type])
-        del menuList[switchObj.business_type]
-        org.active_menu = json.dumps(menuList)
-        db.commit()
-        db.refresh(org)
-        return org
-    else:
-        raise LookupError("We could not find Business")
-
-
-async def pinMenuItem(pinObj: organisation_schemas.PinOrUnpin, db: _orm.Session):
-    org = await fetchOrganization(pinObj.id, db)
-    if org:
-        menuList = json.loads(org.menu_list)
-        # activeMenu =

--- a/bigfastapi/models/organisation_models.py
+++ b/bigfastapi/models/organisation_models.py
@@ -1,4 +1,5 @@
 import datetime as _dt
+from email.policy import default
 from sqlite3 import Timestamp
 import sqlalchemy as _sql
 import sqlalchemy.orm as _orm
@@ -30,6 +31,7 @@ class Organization(Base):
     address = Column(String(255), index=True)
     tagline = Column(String(255), index=True)
     image = Column(String(255), default="")
+    active_menu = Column(String(2000), default="")
     is_deleted = Column(Boolean(), default=False)
     current_subscription = Column(String(225), default="")
     credit_balance = Column(Integer, default=5000) 

--- a/bigfastapi/models/organisation_models.py
+++ b/bigfastapi/models/organisation_models.py
@@ -1,5 +1,7 @@
+from ast import Str
 import datetime as _dt
 from email.policy import default
+import json
 from sqlite3 import Timestamp
 import sqlalchemy as _sql
 import sqlalchemy.orm as _orm
@@ -13,9 +15,11 @@ from sqlalchemy.sql import func
 from fastapi_utils.guid_type import GUID, GUID_DEFAULT_SQLITE
 
 
-
-
 from bigfastapi.db.database import Base
+from bigfastapi.schemas import organisation_schemas
+from bigfastapi.schemas.organisation_schemas import BusinessSwitch
+from bigfastapi.utils.utils import defaultManu
+
 
 class Organization(Base):
     __tablename__ = "businesses"
@@ -26,25 +30,26 @@ class Organization(Base):
     values = Column(String(255), index=True)
     currency = Column(String(5), index=True)
     name = Column(String(255), unique=True, index=True, default="")
+    busines_type = Column(String(225), default="retail")
     country = Column(String(255), index=True)
     state = Column(String(255), index=True)
     address = Column(String(255), index=True)
     tagline = Column(String(255), index=True)
     image = Column(String(255), default="")
-    active_menu = Column(String(2000), default="")
     is_deleted = Column(Boolean(), default=False)
     current_subscription = Column(String(225), default="")
-    credit_balance = Column(Integer, default=5000) 
+    credit_balance = Column(Integer, default=5000)
     currency_preference = Column(String(255), default="")
     email = Column(String(255), default="", index=True)
     phone_number = Column(String(255), default="", index=True)
     date_created = Column(DateTime, default=_dt.datetime.utcnow)
     last_updated = Column(DateTime, default=_dt.datetime.utcnow)
 
+
 class DefaultTemplates(Base):
     __tablename__ = "default_templates"
     id = Column(String(255), primary_key=True, index=True, default=uuid4().hex)
-    organization_id = Column( String(255), ForeignKey("businesses.id"))
+    organization_id = Column(String(255), ForeignKey("businesses.id"))
     greeting = Column(String(225), index=True)
     subject = Column(String(255), index=True)
     escalation_level = Column(Integer, index=True)
@@ -53,3 +58,37 @@ class DefaultTemplates(Base):
     sms_message = Column(String(500), index=True)
     is_deleted = Column(Boolean, default=False)
     date_created = Column(DateTime, default=_dt.datetime.utcnow)
+
+
+# --------------------------------------------------------------------------------------------------#
+#                                    REPOSITORY AND HELPERS
+# --------------------------------------------------------------------------------------------------#
+
+def getActiveMenu(businessType):
+    menuList = defaultManu()
+    return menuList[businessType]
+
+
+async def fetchOrganization(orgId: str, db: _orm.Session):
+    return db.query(Organization).filter(Organization.id == orgId).first()
+
+
+async def switchType(switchObj: BusinessSwitch, db: _orm.Session):
+    org = await fetchOrganization(switchObj.id, db)
+    if org:
+        menuList = json.loads(org.menu_list)
+        org.active_menu = json.dumps(menuList[switchObj.business_type])
+        del menuList[switchObj.business_type]
+        org.active_menu = json.dumps(menuList)
+        db.commit()
+        db.refresh(org)
+        return org
+    else:
+        raise LookupError("We could not find Business")
+
+
+async def pinMenuItem(pinObj: organisation_schemas.PinOrUnpin, db: _orm.Session):
+    org = await fetchOrganization(pinObj.id, db)
+    if org:
+        menuList = json.loads(org.menu_list)
+        # activeMenu =

--- a/bigfastapi/organization.py
+++ b/bigfastapi/organization.py
@@ -1,4 +1,5 @@
 import datetime as _dt
+import json
 import os
 from uuid import uuid4
 
@@ -11,6 +12,8 @@ from fastapi.responses import FileResponse
 from sqlalchemy import and_
 
 from bigfastapi.db.database import get_db
+from bigfastapi.models import menu_model, organisation_models
+from bigfastapi.models.menu_model import addDefaultMenuList, getOrgMenu
 from bigfastapi.schemas import roles_schemas
 from .auth_api import is_authenticated
 from .files import upload_image
@@ -20,31 +23,38 @@ from .models import store_user_model, user_models, store_invite_model, role_mode
 from .models import wallet_models as wallet_models
 from .schemas import organisation_schemas as _schemas
 from .schemas import users_schemas
-from .utils.utils import paginate_data, row_to_dict
+from .utils.utils import defaultManu, paginate_data, row_to_dict
 
 app = APIRouter(tags=["Organization"])
 
 
-@app.post("/organizations", response_model=_schemas.Organization)
-async def create_organization(
+@app.post("/organizations")
+def create_organization(
         organization: _schemas.OrganizationCreate,
         user: str = _fastapi.Depends(is_authenticated),
         db: _orm.Session = _fastapi.Depends(get_db),
 ):
-    db_org = await get_orgnanization_by_name(name=organization.name, db=db)
+    db_org = get_orgnanization_by_name(name=organization.name, db=db)
 
     if db_org:
         raise _fastapi.HTTPException(
             status_code=400, detail="Organization name already in use")
-    created_org = await create_organization(user=user, db=db, organization=organization)
+    created_org = create_organization(
+        user=user, db=db, organization=organization)
 
-    if organization.add_template == True:
-        template_obj = _models.DefaultTemplates(
-            id=uuid4().hex, organization_id=created_org.id, subject="Reminder_One",
-            escalation_level=1, email_message="This is the first default email template created for this business.",
-            sms_message="This is the first default sms template created for this business",
-            is_deleted=False, greeting="Reminder_Greetings", template_type="BOTH"
-        )
+    assocMenu = addDefaultMenuList(
+        created_org.id, created_org.busines_type, db)
+
+    runWalletCreation(created_org, db)
+
+    try:
+        if organization.add_template == True:
+            template_obj = _models.DefaultTemplates(
+                id=uuid4().hex, organization_id=created_org.id, subject="Reminder_One",
+                escalation_level=1, email_message="This is the first default email template created for this business.",
+                sms_message="This is the first default sms template created for this business",
+                is_deleted=False, greeting="Reminder_Greetings", template_type="BOTH"
+            )
 
         db.add(template_obj)
         db.commit()
@@ -61,7 +71,15 @@ async def create_organization(
         db.commit()
         db.refresh(template_obj)
 
-    return created_org
+    except print("ail To Create Templates"):
+        pass
+
+    newOrId = created_org.id
+    newOrg = created_org
+    newMenList = assocMenu["menu_list"]
+    newMenu = assocMenu
+
+    return {"data": {"business": newOrg, "menu": newMenu}}
 
 
 @app.get("/organizations")
@@ -82,7 +100,9 @@ async def get_organization(
         user: users_schemas.User = _fastapi.Depends(is_authenticated),
         db: _orm.Session = _fastapi.Depends(get_db),
 ):
-    return await get_organization(organization_id, user, db)
+    organization = await get_organization(organization_id, user, db)
+    menu = await getOrgMenu(organization_id, db)
+    return {"data": {"organization": organization, "menu": menu}}
 
 
 @app.get("/organizations/{organization_id}/users", status_code=200)
@@ -105,8 +125,8 @@ async def get_organization_users(
 
     organization = (
         db.query(_models.Organization)
-            .filter(_models.Organization.id == organization_id)
-            .first()
+        .filter(_models.Organization.id == organization_id)
+        .first()
     )
 
     if organization is None:
@@ -115,8 +135,8 @@ async def get_organization_users(
     store_owner_id = organization.creator
     store_owner = (
         db.query(user_models.User)
-            .filter(user_models.User.id == store_owner_id)
-            .first())
+        .filter(user_models.User.id == store_owner_id)
+        .first())
 
     invited_users = []
     if len(invited_list) > 0:
@@ -148,17 +168,18 @@ def delete_organization_user(
         db: _orm.Session = _fastapi.Depends(get_db)
 ):
     # fetch the organization user from the user table
-    user = db.query(user_models.User).filter(user_models.User.id == user_id).first()
+    user = db.query(user_models.User).filter(
+        user_models.User.id == user_id).first()
 
     if user is not None:
         # fetch the store user from the store user table.
         store_user = (
             db.query(store_user_model.StoreUser)
-                .filter(and_(
-                store_user_model.StoreUser.user_id == user_id,
-                store_user_model.StoreUser.store_id == organization_id
-            ))
-                .first()
+            .filter(and_(
+                    store_user_model.StoreUser.user_id == user_id,
+                    store_user_model.StoreUser.store_id == organization_id
+                    ))
+            .first()
         )
 
         store_user.is_deleted = True
@@ -177,7 +198,8 @@ def delete_organization_user(
 
 @app.get("/organizations/{organization_id}/roles")
 def get_roles(organization_id: str, db: _orm.Session = _fastapi.Depends(get_db)):
-    roles = db.query(role_models.Role).filter(role_models.Role.organization_id == organization_id)
+    roles = db.query(role_models.Role).filter(
+        role_models.Role.organization_id == organization_id)
     roles = list(map(roles_schemas.Role.from_orm, roles))
 
     return roles
@@ -194,8 +216,8 @@ def add_role(payload: roles_schemas.AddRole,
     if len(roles) < 1:
         existing_role = (
             db.query(role_models.Role)
-                .filter(role_models.Role.role_name == payload.role_name.lower())
-                .first()
+            .filter(role_models.Role.role_name == payload.role_name.lower())
+            .first()
         )
         if existing_role is None:
             role = role_models.Role(
@@ -221,13 +243,13 @@ def get_pending_invites(
 ):
     pending_invites = (
         db.query(store_invite_model.StoreInvite)
-            .filter(
+        .filter(
             and_(store_invite_model.StoreInvite.store_id == organization_id,
                  store_invite_model.StoreInvite.is_deleted == False,
                  store_invite_model.StoreInvite.is_accepted == False,
                  store_invite_model.StoreInvite.is_revoked == False
                  ))
-            .all()
+        .all()
     )
 
     return pending_invites
@@ -294,7 +316,7 @@ async def delete_organization(organization_id: str, user: users_schemas.User = _
 # /////////////////////////////////////////////////////////////////////////////////
 # Organisation Services
 
-async def get_orgnanization_by_name(name: str, db: _orm.Session):
+def get_orgnanization_by_name(name: str, db: _orm.Session):
     return db.query(_models.Organization).filter(_models.Organization.name == name).first()
 
 
@@ -303,36 +325,37 @@ async def fetch_organization_by_name(name: str, organization_id: str, db: _orm.S
         _models.Organization.id != organization_id).first()
 
 
-async def create_organization(user: users_schemas.User, db: _orm.Session, organization: _schemas.OrganizationCreate):
+def create_organization(user: users_schemas.User, db: _orm.Session, organization: _schemas.OrganizationCreate):
     organization_id = uuid4().hex
-    organization = _models.Organization(id=organization_id, creator=user.id, mission=organization.mission,
-                                        vision=organization.vision, values=organization.values, name=organization.name,
-                                        country=organization.country,
-                                        state=organization.state, address=organization.address,
-                                        tagline=organization.tagline, image=organization.image, is_deleted=False,
-                                        current_subscription=organization.current_subscription,
-                                        currency_preference=organization.currency_preference)
+    newOrganization = _models.Organization(id=organization_id, creator=user.id, mission=organization.mission,
+                                           vision=organization.vision, values=organization.values, name=organization.name,
+                                           country=organization.country,
+                                           state=organization.state, address=organization.address,
+                                           tagline=organization.tagline, image=organization.image, is_deleted=False,
+                                           current_subscription=organization.current_subscription,
+                                           currency_preference=organization.currency_preference)
 
-    db.add(organization)
+    db.add(newOrganization)
     db.commit()
-    db.refresh(organization)
+    db.refresh(newOrganization)
+    return newOrganization
 
+
+def runWalletCreation(newOrganization: organisation_models.Organization, db: _orm.Session):
     roles = ["Assistant", "Admin", "Owner"]
-
     for role in roles:
         new_role = role_models.Role(
             id=uuid4().hex,
-            organization_id=organization.id.strip(),
+            organization_id=newOrganization.id.strip(),
             role_name=role.lower()
         )
         db.add(new_role)
         db.commit()
         db.refresh(new_role)
 
-    await create_wallet(organization_id=organization_id, currency=organization.currency_preference, db=db)
-    await create_credit_wallet(organization_id=organization_id, db=db)
-
-    return _schemas.Organization.from_orm(organization)
+    create_wallet(organization_id=newOrganization.id,
+                  currency=newOrganization.currency_preference, db=db)
+    create_credit_wallet(organization_id=newOrganization.id, db=db)
 
 
 async def get_organizations(user: users_schemas.User, db: _orm.Session):
@@ -341,8 +364,8 @@ async def get_organizations(user: users_schemas.User, db: _orm.Session):
 
     invited_orgs_rep = (
         db.query(store_user_model.StoreUser)
-            .filter(store_user_model.StoreUser.user_id == user.id)
-            .all()
+        .filter(store_user_model.StoreUser.user_id == user.id)
+        .all()
     )
 
     if len(invited_orgs_rep) < 1:
@@ -352,7 +375,7 @@ async def get_organizations(user: users_schemas.User, db: _orm.Session):
         for pos in range(len(organization_list)):
             appBasePath = config('API_URL')
             imageURL = appBasePath + \
-                       f'/organizations/{organization_list[pos].id}/image'
+                f'/organizations/{organization_list[pos].id}/image'
             setattr(organization_list[pos], 'image_full_path', imageURL)
             organizationCollection.append(organization_list[pos])
 
@@ -363,8 +386,8 @@ async def get_organizations(user: users_schemas.User, db: _orm.Session):
     org = []
     for store_id in store_id_list:
         org = org + \
-              db.query(_models.Organization).filter(
-                  _models.Organization.id == store_id).all()
+            db.query(_models.Organization).filter(
+                _models.Organization.id == store_id).all()
 
     org_coll = native_orgs + org
     organizationCollection = []
@@ -380,8 +403,8 @@ async def get_organizations(user: users_schemas.User, db: _orm.Session):
 async def _organization_selector(organization_id: str, user: users_schemas.User, db: _orm.Session):
     organization = (
         db.query(_models.Organization)
-            .filter(_models.Organization.id == organization_id)
-            .first()
+        .filter(_models.Organization.id == organization_id)
+        .first()
     )
 
     if organization is None:
@@ -461,7 +484,7 @@ async def update_organization(organization_id: str, organization: _schemas.Organ
     return _schemas.Organization.from_orm(organization_db)
 
 
-async def create_wallet(organization_id: str, currency: str, db: _orm.Session):
+def create_wallet(organization_id: str, currency: str, db: _orm.Session):
     currency = currency.upper()
     wallet = db.query(wallet_models.Wallet).filter_by(organization_id=organization_id).filter_by(
         currency_code=currency).first()
@@ -476,8 +499,9 @@ async def create_wallet(organization_id: str, currency: str, db: _orm.Session):
         db.refresh(wallet)
 
 
-async def create_credit_wallet(organization_id: str, db: _orm.Session):
-    default_credit_wallet_balance = int(config('DEFAULT_CREDIT_WALLET_BALANCE'))
+def create_credit_wallet(organization_id: str, db: _orm.Session):
+    default_credit_wallet_balance = int(
+        config('DEFAULT_CREDIT_WALLET_BALANCE'))
     credit = credit_wallet_models.CreditWallet(id=uuid4().hex, organization_id=organization_id,
                                                amount=default_credit_wallet_balance,
                                                last_updated=_dt.datetime.utcnow())

--- a/bigfastapi/organization.py
+++ b/bigfastapi/organization.py
@@ -43,7 +43,7 @@ def create_organization(
         user=user, db=db, organization=organization)
 
     assocMenu = addDefaultMenuList(
-        created_org.id, created_org.busines_type, db)
+        created_org.id, created_org.business_type, db)
 
     runWalletCreation(created_org, db)
 
@@ -329,7 +329,7 @@ def create_organization(user: users_schemas.User, db: _orm.Session, organization
     organization_id = uuid4().hex
     newOrganization = _models.Organization(id=organization_id, creator=user.id, mission=organization.mission,
                                            vision=organization.vision, values=organization.values, name=organization.name,
-                                           country=organization.country,
+                                           country=organization.country, business_type=organization.business_type,
                                            state=organization.state, address=organization.address,
                                            tagline=organization.tagline, image=organization.image, is_deleted=False,
                                            current_subscription=organization.current_subscription,

--- a/bigfastapi/schemas/organisation_schemas.py
+++ b/bigfastapi/schemas/organisation_schemas.py
@@ -23,6 +23,7 @@ class _OrganizationBase(_pydantic.BaseModel):
     tagline: Optional[str]
     image: Optional[str]
     values: Optional[str]
+    business_type: str = "retail"
     credit_balance: Optional[int]
     image_full_path: str = None
     add_template: Optional[bool]
@@ -45,6 +46,22 @@ class Organization(_OrganizationBase):
 
     date_created: _dt.datetime
     last_updated: _dt.datetime
+
+    class Config:
+        orm_mode = True
+
+
+class BusinessSwitch(_pydantic.BaseModel):
+    id: str
+    business_type: str
+
+    class Config:
+        orm_mode = True
+
+
+class PinOrUnpin(BusinessSwitch):
+    menu_item: str
+    action: str
 
     class Config:
         orm_mode = True

--- a/bigfastapi/utils/utils.py
+++ b/bigfastapi/utils/utils.py
@@ -52,18 +52,22 @@ def find_country(ctry):
     with open(DATA_PATH + "/countries.json") as file:
         cap_country = ctry.capitalize()
         countries = json.load(file)
-        found_country = next((country for country in countries if country['name'] == cap_country), None)
+        found_country = next(
+            (country for country in countries if country['name'] == cap_country), None)
         if found_country is None:
-            raise fastapi.HTTPException(status_code=403, detail="This country doesn't exist")
+            raise fastapi.HTTPException(
+                status_code=403, detail="This country doesn't exist")
         return found_country['name']
 
 
 def dialcode(dcode):
     with open(DATA_PATH + "/dialcode.json") as file:
         dialcodes = json.load(file)
-        found_dialcode = next((dialcode for dialcode in dialcodes if dialcode['dial_code'] == dcode), None)
+        found_dialcode = next(
+            (dialcode for dialcode in dialcodes if dialcode['dial_code'] == dcode), None)
         if found_dialcode is None:
-            raise fastapi.HTTPException(status_code=403, detail="This is an invalid dialcode")
+            raise fastapi.HTTPException(
+                status_code=403, detail="This is an invalid dialcode")
         return found_dialcode['dial_code']
 
 
@@ -72,7 +76,8 @@ def generate_code(new_length: int = None):
     if new_length is not None:
         length = new_length
     if length < 4:
-        raise fastapi.HTTPException(status_code=400, detail="Minimum code lenght is 4")
+        raise fastapi.HTTPException(
+            status_code=400, detail="Minimum code lenght is 4")
     code = ""
     for i in range(length):
         code += str(random.randint(0, 9))
@@ -104,8 +109,10 @@ async def generate_payment_link(api_redirect_url: str,
                 client_reference_id=tx_ref,
                 metadata={'redirect_url': front_end_redirect_url},
                 mode='payment',
-                success_url=api_redirect_url + "?status=successful&tx_ref=" + tx_ref + "&transaction_id={CHECKOUT_SESSION_ID}",
-                cancel_url=api_redirect_url + "?status=cancelled&tx_ref=" + tx_ref + "&transaction_id={CHECKOUT_SESSION_ID}",
+                success_url=api_redirect_url + "?status=successful&tx_ref=" +
+                tx_ref + "&transaction_id={CHECKOUT_SESSION_ID}",
+                cancel_url=api_redirect_url + "?status=cancelled&tx_ref=" +
+                tx_ref + "&transaction_id={CHECKOUT_SESSION_ID}",
             )
             return session.url
         except InvalidRequestError as e:
@@ -113,7 +120,8 @@ async def generate_payment_link(api_redirect_url: str,
                                         detail=str(e))
     else:
         flutterwaveKey = config('FLUTTERWAVE_SEC_KEY')
-        headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + flutterwaveKey}
+        headers = {'Content-Type': 'application/json',
+                   'Authorization': 'Bearer ' + flutterwaveKey}
         url = 'https://api.flutterwave.com/v3/payments/'
         username = user.email if user.first_name is None else user.first_name
         username += '' if user.last_name is None else ' ' + user.last_name
@@ -146,3 +154,26 @@ def row_to_dict(row):
     for column in row.__table__.columns:
         d[column.name] = str(getattr(row, column.name))
     return d
+
+
+# MENU RELATED DEFAULTS
+def defaultManu():
+    default_more_list = ['reports', 'invoice', 'fees', 'tutorials',
+                         'sales', 'debts', 'receipts', 'products', 'payments']
+
+    default_retail = ['dashboard', 'customers',
+                      'debts', 'payments', 'settings', 'more']
+
+    default_edu = ['dashboard', 'student', 'settings', 'more']
+
+    default_hos = ['dashboard', 'reservations',
+                   'customers', 'settings', 'more']
+
+    default_freeLance = ['dashboard', 'clients', 'settings', 'more']
+
+    return {
+        "education": {"menu": default_edu, 'more': default_more_list},
+        "hospitality": {"menu": default_hos, "more": default_more_list},
+        "retail": {"menu": default_retail, 'more': default_more_list},
+        "freelancce": {"menu": default_freeLance, "more": default_more_list}
+    }


### PR DESCRIPTION
## Context
To enable features like business type switching and rearranging of menu items, organizations need to have a default menu setup upon creation. This PR proposes the needed menu setup for organizations.

## Major Files Added
- Alembic migration file to add an extra column ( business_type ) to the organization's table
- menu_model.py file to contain logic of menu setup

## Major Code Modifications
- Adapted the create organization API to accommodate for organization default menu setup upon creating an organization
- Modified Organization model to include business_type as an added attribute
- Added a brief Repository layer to the organization_model file to help with queries related to the organization menu